### PR TITLE
Update nodemailer-openpgp.js

### DIFF
--- a/lib/nodemailer-openpgp.js
+++ b/lib/nodemailer-openpgp.js
@@ -92,7 +92,7 @@ class Encrypter extends Transform {
                     bodyHeaders = bodyHeaders.map(line => line.join('\r\n')).join('\r\n');
 
                     let body = messageParts.join('\r\n\r\n');
-                    const data = `${bodyHeaders} \r\n\r\n ${body}`;
+                    const data = `${bodyHeaders}\r\n\r\n${body}`;
 
                     const signature = await openpgp.sign({
                         message: await openpgp.createMessage({ text: data }),


### PR DESCRIPTION
need to remove the spaces because they appear in the message body. all messages started with a space " ". ugly.